### PR TITLE
Pricing is now an int

### DIFF
--- a/src/OpenRealEstate.Core/Rental/RentalPricing.cs
+++ b/src/OpenRealEstate.Core/Rental/RentalPricing.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 
 namespace OpenRealEstate.Core.Rental
 {
     public class RentalPricing
     {
-        public decimal RentalPrice { get; set; }
+        public int RentalPrice { get; set; }
 
         public PaymentFrequencyType PaymentFrequencyType { get; set; }
 
@@ -12,7 +12,7 @@ namespace OpenRealEstate.Core.Rental
 
         public DateTime? RentedOn { get; set; }
 
-        public decimal? Bond { get; set; }
+        public int? Bond { get; set; }
 
         public override string ToString()
         {

--- a/src/OpenRealEstate.Core/SalePricing.cs
+++ b/src/OpenRealEstate.Core/SalePricing.cs
@@ -1,14 +1,14 @@
-﻿using System;
+using System;
 
 namespace OpenRealEstate.Core
 {
     public class SalePricing
     {
-        public decimal SalePrice { get; set; }
+        public int SalePrice { get; set; }
 
         public string SalePriceText { get; set; }
 
-        public decimal? SoldPrice { get; set; }
+        public int? SoldPrice { get; set; }
 
         public string SoldPriceText { get; set; }
 


### PR DESCRIPTION
This is to help mainly with Json serialization .. but it's good to make it an `int` because agents do use cents in their pricing.